### PR TITLE
Use explicit array item key for errorsSchema

### DIFF
--- a/validation-error.js
+++ b/validation-error.js
@@ -9,7 +9,8 @@ const errorSchema = new SimpleSchema({
 });
 
 const errorsSchema = new SimpleSchema({
-  errors: {type: [errorSchema]}
+  errors: {type: Array},
+  'errors.$': {type: errorSchema}
 });
 
 ValidationError = class extends Meteor.Error {


### PR DESCRIPTION
In SimpleSchema 2.0, I am going to require explicit definition of the array item ".$" key, and the `[type]` shortcut will no longer work. This change allows this package to continue to work with SimpleSchema v1 or v2.
