### PR TITLE
Remove check dependency, allow custom message

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,9 @@ Template.foo.events({
 ### Works out of the box with mdg:method
 
 This type of error is automatically thrown for invalid arguments if you use the [`mdg:method`](https://github.com/meteor/method) package, where you can specify a schema for the arguments of your method.
+
+### Running tests
+
+```bash
+$ meteor test-packages --driver-package practicalmeteor:mocha ./
+```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This error format is based on the error output of [`aldeed:simple-schema`](https
 
 ## API
 
-### new ValidationError(errors: Array)
+### new ValidationError(errors: Array, [message: String])
 
 `errors` must be a array with keys of the form:
 
@@ -38,6 +38,8 @@ This error format is based on the error output of [`aldeed:simple-schema`](https
   ...
 ]
 ```
+
+`message` is an optional string to use for the error message so that the text printed at the top of the stack trace when the error is thrown is more useful. For example, if you pass in the error `{name: 'name', type: 'required'}`, you may want to also pass in the message "Name is required".
 
 ### Usage example
 

--- a/package.js
+++ b/package.js
@@ -10,11 +10,21 @@ Package.onUse(function(api) {
 
   api.use([
     'ecmascript',
-    'aldeed:simple-schema@1.3.3',
-    'check'
+    'aldeed:simple-schema@1.5.1',
   ]);
 
   api.addFiles('validation-error.js');
 
   api.export('ValidationError');
+});
+
+Package.onTest(function (api) {
+  api.use([
+    'ecmascript',
+    'practicalmeteor:mocha@2.1.0_5',
+    'practicalmeteor:chai@2.1.0_1',
+    'mdg:validation-error',
+  ]);
+
+  api.addFiles('validation-error-tests.js');
 });

--- a/validation-error-tests.js
+++ b/validation-error-tests.js
@@ -1,0 +1,30 @@
+describe('ValidationError', () => {
+  it('throws a useful error when the argument is not correct', () => {
+    try {
+      new ValidationError([{name: 'name'}]);
+    } catch (error) {
+      // Welcome to Bizarro World, where ValidationError constructor actually throws
+      // a ValidationError when the arguments aren't correct.
+      assert.equal(error.error, 'validation-error');
+      assert.equal(error.details, error.errors);
+      assert.equal(error.errors[0].name, 'errors.0.type');
+      assert.equal(error.errors[0].type, 'required');
+    }
+  });
+
+  it('allows message to be passed in', () => {
+    // We need to make sure the that error printed at the top of the stack trace when
+    // this is thrown contains the necessary information to deal with the error.
+    // So we allow message to be passed in, which can contain the error message for the
+    // first error in the array.
+    try {
+      throw new ValidationError([{
+        name: 'name',
+        type: 'required'
+      }], 'Name is required');
+    } catch (error) {
+      assert.equal(error.error, 'validation-error');
+      assert.equal(error.message, 'Name is required [validation-error]');
+    }
+  });
+});

--- a/validation-error.js
+++ b/validation-error.js
@@ -13,10 +13,10 @@ const errorsSchema = new SimpleSchema({
 });
 
 ValidationError = class extends Meteor.Error {
-  constructor(errors) {
-    check({errors}, errorsSchema);
+  constructor(errors, message = 'Validation Failed') {
+    errorsSchema.validate({errors});
 
-    super(ValidationError.ERROR_CODE, 'Validation Failed', errors);
+    super(ValidationError.ERROR_CODE, message, errors);
 
     this.errors = errors;
   }


### PR DESCRIPTION
1. I removed the `check` dependency and changed it to use `ss.validate`. (In the next version of simple-schema, I plan to remove compatibility with `check` pkg in favor of `validate` method.) There is an interesting partially circular reference between this pkg and SS here, but it should be fine.
2. You can now pass a custom error message for the top of the stack trace. When this is merged, I'll update SimpleSchema `validate` to get the error message for the first error and pass that in. (closes #2)
3. Added a couple tests.

@tmeasday @stubailo 
