### PR TITLE
Add type check helper

### DIFF
--- a/validation-error.js
+++ b/validation-error.js
@@ -14,6 +14,10 @@ ValidationError = class extends Meteor.Error {
 
     super(ValidationError.ERROR_CODE, message, errors);
   }
+  
+  static isInstance(err) {
+    return err && err instanceof Meteor.Error && err.error === ValidationError.ERROR_CODE;
+  }
 };
 
 // If people use this to check for the error code, we can change it


### PR DESCRIPTION
I would like to propose adding a simple helper for checking type of the error that would be called in the following way:

``` js
Meteor.call('methodName', function(err) {
  if (ValidationError.isInstance(err)) {
  }
});
```

The issue that it solves is a necessity for checking the `error` property of the error to make sure that it's a validation error. The problem only occurs when error is throw from the server and we catch it on the client. Even if we throw `ValidationError` we will receive `Meteor.Error` on the client, because class constructor is not send over the wire. So we have to make additional check.

Feel free to change helper name
