### PR TITLE
Make package compatible with SimpleSchema and Astronomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,34 +12,45 @@ Use a validation error to indicate that a method call has failed and the client 
 
 This kind of error is tied to a specific field so that you can display it next to an input in a form currently being filled by the user.
 
-This error format is based on the error output of [`aldeed:simple-schema`](https://github.com/aldeed/meteor-simple-schema).
+This error format is based on the error output of [`aldeed:simple-schema`](https://github.com/aldeed/meteor-simple-schema) and is also compatible with the error output of [`jagi:astronomy`](https://github.com/jagi/meteor-astronomy).
 
 ## API
 
 ### new ValidationError(errors: Array, [message: String])
 
-`errors` must be a array with keys of the form:
+`errors` must be an array with keys of the form:
 
 ```js
 [
   {
-    // Name of the field this error is about
+    // Name of the field this error is about.
     name: String,
 
-    // Type of error, can be mapped to a nice message
-    // on the client
+    // Type of error, can be mapped to a nice message on the client.
     type: String,
 
-    // Any kind of details, depends on the type of error.
-    // Should probably include a `value` field that
-    // contains the invalid value passed from the client.
-    details: Object
+    // Any kind of details that depends on the type of error can be added as
+    // an extra object's property (eg. `message` with a per field error message
+    // or `value` that contains the invalid value passed from the client).
+    ...
   }
   ...
 ]
 ```
 
 `message` is an optional string to use for the error message so that the text printed at the top of the stack trace when the error is thrown is more useful. For example, if you pass in the error `{name: 'name', type: 'required'}`, you may want to also pass in the message "Name is required".
+
+### ValidationError.is(error: Meteor.Error)
+
+The static `ValidationError.is` method is a helper for checking if an error thrown by a server and catched on the client is an instance of `ValidationError`.
+
+```js
+Meteor.call('method', (err) => {
+  if (ValidationError.is(err)) {
+    ...
+  }
+});
+```
 
 ### Usage example
 
@@ -51,11 +62,9 @@ saveProduct({ name, cost, category }) {
       {
         name: 'cost',
         type: 'out-of-range',
-        details: {
-          value: cost,
-          min: 0,
-          max: 100
-        }
+        value: cost,
+        min: 0,
+        max: 100
       }
     ]);
   }
@@ -70,7 +79,7 @@ You might catch the error returned by a method call and display it in the UI:
 Template.foo.events({
   'submit': (event, instance) => {
     Meteor.call('method', (err) => {
-      if (err && err.error === ValidationError.ERROR_CODE) {
+      if (ValidationError.is(err)) {
         err.details.forEach((fieldError) => {
           instance.state.set(`error-${fieldError.name}`: fieldError.type);
         });


### PR DESCRIPTION
Hi @stubailo. We've talked today with @aldeed about SimpleSchema and Astronomy. We've discussed how validation work in SS and A and if the `mdg:validation-error` package fits our needs. We've came to conclusion that it needs one little change. Instead have the `details` property per error it's better to keep errors structure plain and keep fields like `value`, `message` on the same level as `type` and `name`. @aldeed is already using such structure and me too in Astronomy 2.0.

I've also added several improvements that I'm using in Astronomy like:

``` js
if (ValidationError.is(err)) {
}
```

for checking if error is an instance of ValidationError. It's much shorter than:

``` js
if (err && err.error === ValidationError.ERROR_CODE) {
}
```

I've also added possibility to change default error message by overriding static property:

``` js
ValidationError.DEFAULT_MESSAGE = 'Validation error';
```
